### PR TITLE
Fix perk lottery for exactly 4 perks

### DIFF
--- a/src/services/SeedInfo/infoHandler.ts
+++ b/src/services/SeedInfo/infoHandler.ts
@@ -836,7 +836,7 @@ export class LotteryInfoProvider extends InfoProvider {
     // Since we use 0..n-1 instead of 1..n, we use `+ 0.5` since we can
     // think of this as `i + 1 - 0.5`, which can be simplified to
     // `i + 0.5`
-    const perkX = x + this.toInt((perkNumber + 0.5) * (60 / perksOnLevel)) + (35840 * worldOffset);
+    const perkX = this.toInt(x + (perkNumber + 0.5) * (60 / perksOnLevel)) + (35840 * worldOffset);
     const probability = 100 * Math.pow(0.5, lotteries);
     this.randoms.SetRandomSeed(perkX, perkY);
     return !(this.randoms.Random(1, 100) <= probability);


### PR DESCRIPTION
The special cases in toInt are based on the final world coordinates, therefore the temple offset needs to be added as well