### PR TITLE
Add perk/spell classes to icons

### DIFF
--- a/src/components/Icons/Perk.tsx
+++ b/src/components/Icons/Perk.tsx
@@ -46,7 +46,7 @@ const Perk = (props: IPerkProps) => {
           />
         )}
         <Icon
-          className={classNames(highlight && "shadow" && "perk")}
+          className={classNames(highlight && "shadow" && "icon-perk")}
           uri={perk.perk_icon}
           alt={t(perk.ui_description)}
           title={t(perk.ui_name)}

--- a/src/components/Icons/Perk.tsx
+++ b/src/components/Icons/Perk.tsx
@@ -46,7 +46,7 @@ const Perk = (props: IPerkProps) => {
           />
         )}
         <Icon
-          className={classNames(highlight && "shadow")}
+          className={classNames(highlight && "shadow" && "perk")}
           uri={perk.perk_icon}
           alt={t(perk.ui_description)}
           title={t(perk.ui_name)}

--- a/src/components/Icons/Spell.tsx
+++ b/src/components/Icons/Spell.tsx
@@ -21,7 +21,7 @@ const Spell: FC<ISpellProps> = ({ id, className, width, highlight, ...rest }) =>
 
   return (
     <Icon
-      className={classNames(className, highlight && "shadow" && "spell")}
+      className={classNames(className, highlight && "shadow" && "icon-spell")}
       width={width || "2rem"}
       uri={item.sprite}
       title={t(item.name)}

--- a/src/components/Icons/Spell.tsx
+++ b/src/components/Icons/Spell.tsx
@@ -21,7 +21,7 @@ const Spell: FC<ISpellProps> = ({ id, className, width, highlight, ...rest }) =>
 
   return (
     <Icon
-      className={classNames(className, highlight && "shadow")}
+      className={classNames(className, highlight && "shadow" && "spell")}
       width={width || "2rem"}
       uri={item.sprite}
       title={t(item.name)}


### PR DESCRIPTION
Added "perk" and "spell" classes to the relevant icons for ease of selecting in, and futureproofing of, wikilink userscript.

(Would ideally like to integrate linking directly but there's further considerations before going down that road)

Not hugely familiar with React so apologies if I've missed anything.