### PR TITLE
add preview for favorite spells in shop row

### DIFF
--- a/src/components/Icons/BadgesWrapper.tsx
+++ b/src/components/Icons/BadgesWrapper.tsx
@@ -18,7 +18,7 @@ export default function BadgesWrapper({ children, badges, size = 1 }: { children
     }
 
     return (
-        <div className="position-relative" style={{ marginBottom: "-0.7rem" }}>
+        <div className="position-relative">
           {children}
           <div className="position-absolute" style={{
             top: "-0.2rem",

--- a/src/components/Icons/BadgesWrapper.tsx
+++ b/src/components/Icons/BadgesWrapper.tsx
@@ -1,14 +1,8 @@
-/* 
-TODO planned and discussed
-  unshure how to work with badges maybe refactor the alwaysCast from Perk to use Icon with Badge instead background paramenter.
- skipped sizing for now
-*/
-export const CountBadge = ({text} : {text: String}) => (<div className="bg-white text-black link-black" style={{ 
+export const CountBadge = ({text} : {text: String}) => (<div className="text-body" style={{ 
     fontSize: "0.5rem",
     lineHeight: "0.8rem",
     width: "0.7rem", 
     height: "0.7rem", 
-    borderRadius: "50%"
 }}>{text}</div>);
 
 

--- a/src/components/Icons/BadgesWrapper.tsx
+++ b/src/components/Icons/BadgesWrapper.tsx
@@ -1,0 +1,29 @@
+/* 
+TODO planned and discussed
+  unshure how to work with badges maybe refactor the alwaysCast from Perk to use Icon with Badge instead background paramenter.
+ skipped sizing for now
+*/
+export const CountBadge = ({text} : {text: String}) => (<div className="bg-white text-black link-black" style={{ 
+    fontSize: "0.5rem",
+    lineHeight: "0.8rem",
+    width: "0.7rem", 
+    height: "0.7rem", 
+    borderRadius: "50%"
+}}>{text}</div>);
+
+
+export default function BadgesWrapper({ children, badges, size = 1 }: { children: React.ReactNode; badges: React.ReactNode[], size?: number }) {
+    if (badges.length <= 0) {
+        return <>{children}</>;
+    }
+
+    return (
+        <div className="position-relative" style={{ marginBottom: "-0.7rem" }}>
+          {children}
+          <div className="position-absolute" style={{
+            top: "-0.2rem",
+            right: "-0.2rem",
+          }}>{badges}</div>
+        </div>
+    );
+};

--- a/src/components/SeedInfo/SeedInfoViews/HolyMountain.tsx
+++ b/src/components/SeedInfo/SeedInfoViews/HolyMountain.tsx
@@ -15,6 +15,7 @@ import { Button, Col, Form, Stack, Modal, Row, Table } from "react-bootstrap";
 
 import GameInfoProvider from "../../../services/SeedInfo/infoHandler";
 import WandIcon from "../../Icons/Wand";
+import BadgesWrapper, {CountBadge} from "../../Icons/BadgesWrapper";
 import LightBulletIcon from "../../Icons/LightBullet";
 import { localizeNumber, removeFromArr } from "../../../services/helpers";
 import {
@@ -135,6 +136,26 @@ const PacifistChest: FC<IPacifistChestProps> = ({ items }) => {
 // TODO: Extract this into it's own file to decouple
 const Shop = ({ type, handleOpenShopInfo, favoriteSpells }) => {
   const Icon = type === IShopType.wand ? WandIcon : LightBulletIcon;
+
+  // group duplicate favorite spells and count occurrences
+  const favoriteSpellsGrouped : Map<string, number> = favoriteSpells.reduce((acc, spell) => {
+    acc.set(spell, (acc.get(spell) ?? 0) + 1); return acc;
+  }, new Map<string, number>());
+  
+
+  // add favorite spell icons with badges for counts
+  const favSpellIcons = Array.from(favoriteSpellsGrouped.entries()).map(([spell, count]) => (
+    <BadgesWrapper key={spell} badges={[CountBadge({ text: count.toString() })]}>
+      <Entity
+        key={spell}
+        width="1rem"
+        height="1rem"
+        id="Spell"
+        entityParams={{ extra: spell }}
+      />
+    </BadgesWrapper>
+  ));
+
   return (
     <Button
       className="position-relative"
@@ -142,9 +163,9 @@ const Shop = ({ type, handleOpenShopInfo, favoriteSpells }) => {
       variant={favoriteSpells.length ? "outline-info" : "outline-primary"}
       size="sm"
     >
+      {!favSpellIcons.length ? "" : <div className="d-flex">{favSpellIcons}</div>}
       <Square>
         <Icon />
-        {favoriteSpells.length ? <div className="position-absolute top-0 end-0 pe-1">{favoriteSpells.length}</div> : ""}
       </Square>
     </Button>
   );

--- a/src/components/SeedInfo/SeedInfoViews/HolyMountain.tsx
+++ b/src/components/SeedInfo/SeedInfoViews/HolyMountain.tsx
@@ -158,12 +158,12 @@ const Shop = ({ type, handleOpenShopInfo, favoriteSpells }) => {
 
   return (
     <Button
-      className="position-relative"
+      className="position-relative w-100"
       onClick={handleOpenShopInfo}
       variant={favoriteSpells.length ? "outline-info" : "outline-primary"}
       size="sm"
     >
-      {!favSpellIcons.length ? "" : <div className="d-flex">{favSpellIcons}</div>}
+      {favSpellIcons.length > 0 && <div style={{display: 'grid', gridTemplateColumns: 'repeat(6, 1fr)', marginBottom: '-0.7rem'}}>{favSpellIcons}</div>}
       <Square>
         <Icon />
       </Square>

--- a/src/components/SeedInfo/SeedInfoViews/HolyMountain.tsx
+++ b/src/components/SeedInfo/SeedInfoViews/HolyMountain.tsx
@@ -137,14 +137,15 @@ const PacifistChest: FC<IPacifistChestProps> = ({ items }) => {
 const Shop = ({ type, handleOpenShopInfo, favoriteSpells }) => {
   const Icon = type === IShopType.wand ? WandIcon : LightBulletIcon;
 
+  const [maxFavoriteSpellPreview] = useLocalStorage("favorite-spell-preview-max-count", 2);
+
   // group duplicate favorite spells and count occurrences
   const favoriteSpellsGrouped : Map<string, number> = favoriteSpells.reduce((acc, spell) => {
     acc.set(spell, (acc.get(spell) ?? 0) + 1); return acc;
   }, new Map<string, number>());
-  
 
   // add favorite spell icons with badges for counts
-  const favSpellIcons = Array.from(favoriteSpellsGrouped.entries()).map(([spell, count]) => (
+  let favSpellIcons = Array.from(favoriteSpellsGrouped.entries()).slice(0, maxFavoriteSpellPreview).map(([spell, count]) => (
     <BadgesWrapper key={spell} badges={[CountBadge({ text: count.toString() })]}>
       <Entity
         key={spell}
@@ -155,6 +156,11 @@ const Shop = ({ type, handleOpenShopInfo, favoriteSpells }) => {
       />
     </BadgesWrapper>
   ));
+
+  const countSlicedFavSpells = favoriteSpellsGrouped.size - maxFavoriteSpellPreview;
+  if (countSlicedFavSpells > 0) {
+    favSpellIcons.push(<span key="more" className="text-body" style={{alignSelf: 'center', paddingLeft: '0.2rem', fontSize: '0.7rem'}}>(+{countSlicedFavSpells})</span>);
+  }
 
   return (
     <Button

--- a/src/components/Settings/FavoritesSettings.tsx
+++ b/src/components/Settings/FavoritesSettings.tsx
@@ -72,6 +72,12 @@ const SpellFavorites = () => {
   const query = useLiveQuery(() => db.favorites.where({ type: FavoriteType.Spell }).toArray(), [], []);
   const selected = query.map(q => q.key);
 
+  const [val, setVal] = useLocalStorage("favorite-spell-preview-max-count", 2);
+  const handleRange = (e: any) => {
+    setVal(e.target.valueAsNumber);
+  };
+
+
   return (
     <ConfigRow
       left={
@@ -89,9 +95,17 @@ const SpellFavorites = () => {
             handleSelectedClicked={spell => handleSelect(spell)}
             show={open}
           />
-          <Button onClick={() => setOpen(true)} size="sm">
-            Select Spells
-          </Button>
+          <Stack direction="horizontal">
+            <div className="d-flex justify-content-center">
+              <Form.Group as={Col} xs={6} controlId="code">
+                <Form.Label className="m-0">Preview count: {val}</Form.Label>
+                <Form.Range value={val} onChange={handleRange} min="0" max="12" />
+              </Form.Group>
+            </div>
+            <Button onClick={() => setOpen(true)} size="sm">
+              Select Spells
+            </Button>
+          </Stack>
         </>
       }
     />


### PR DESCRIPTION
# Add preview for shop contained favorite spells + count

I am planning to add this for perk rerolls too, thats why I wrote the BadgeWrapper Component, but I dont know how to do it optimal.
Maybe you have suggetions or recomandations how to do it.

Hope the Feature is in your favor.

<img width="1350" height="786" alt="image" src="https://github.com/user-attachments/assets/6a2bc66f-829e-46d1-8351-0e67077551b5" />
