### PR TITLE
Fix for wrong wiki link

### DIFF
--- a/src/services/helpers.ts
+++ b/src/services/helpers.ts
@@ -128,7 +128,6 @@ const wikiLinkMap: { [spellId: string]: string } = {
   TELEPORTATION_FIELD: "Circle_of_Displacement",
   BERSERK_FIELD: "Circle_of_Fervour",
   SHIELD_FIELD: "Circle_of_Shielding",
-  FREEZE_FIELD: "Circle_of_Stillness",
   POLYMORPH_FIELD: "Circle_of_Transmogrification",
   ELECTROCUTION_FIELD: "Circle_of_Thunder",
   ALCOHOL_BLAST: "Explosion_of_Spirits",


### PR DESCRIPTION
The perk "Freeze Field" and spell "Circle of Stillness" share the same internal ID (FREEZE_FIELD). The wikiLinkMap entry was causing the perk to incorrectly link to the spell's wiki page.

By removing the hardcoded mapping, both now use their translated names:
- Perk: "Freeze Field" -> wiki/Freeze_Field
- Spell: "Circle of stillness" -> wiki/Circle_Of_Stillness

Fixes issue reported by Shareazu on Discord.